### PR TITLE
레이아웃 크기 조절 및 컴포넌트 분리

### DIFF
--- a/src/components/layout/Nav.tsx
+++ b/src/components/layout/Nav.tsx
@@ -1,0 +1,28 @@
+import logo from "@assets/whitelogo.png";
+import { RxExit, RxPerson } from "react-icons/rx";
+import { NavLink } from "react-router-dom";
+
+const Nav = () => {
+  return (
+    <nav className="h-16 w-full overflow-hidden bg-primary">
+      <ul className="flex h-full w-full flex-row items-center justify-between px-4">
+        <li>
+          <NavLink to="/" className="inline-block">
+            <RxExit className="text-3xl font-bold text-white" />
+          </NavLink>
+        </li>
+        <li>
+          <NavLink to="/" className="inline-block">
+            <img src={logo} className="m-auto mt-1 w-24" />
+          </NavLink>
+        </li>
+        <li>
+          <NavLink to="/classroom" className="inline-block">
+            <RxPerson className="text-3xl font-bold text-white" />
+          </NavLink>
+        </li>
+      </ul>
+    </nav>
+  );
+};
+export default Nav;

--- a/src/layouts/BasicLayout.tsx
+++ b/src/layouts/BasicLayout.tsx
@@ -1,31 +1,14 @@
-import logo from "@assets/whitelogo.png";
-import { RxExit, RxPerson } from "react-icons/rx";
-import { NavLink, Outlet } from "react-router-dom";
+import Nav from "@components/layout/Nav";
+import { Outlet } from "react-router-dom";
 
 const BasicLayout = () => {
   return (
-    <>
-      <nav className="h-16 w-full overflow-hidden bg-primary">
-        <ul className="flex h-full w-full flex-row items-center justify-between px-4">
-          <li>
-            <NavLink to="/" className="inline-block">
-              <RxExit className="text-3xl font-bold text-white" />
-            </NavLink>
-          </li>
-          <li>
-            <NavLink to="/" className="inline-block">
-              <img src={logo} className="m-auto mt-1 w-24" />
-            </NavLink>
-          </li>
-          <li>
-            <NavLink to="/classroom" className="inline-block">
-              <RxPerson className="text-3xl font-bold text-white" />
-            </NavLink>
-          </li>
-        </ul>
-      </nav>
-      <Outlet />
-    </>
+    <div className="flex h-full w-full flex-col">
+      <Nav />
+      <main className="flex flex-1">
+        <Outlet />
+      </main>
+    </div>
   );
 };
 export default BasicLayout;

--- a/src/page/ClassRoom.tsx
+++ b/src/page/ClassRoom.tsx
@@ -1,6 +1,6 @@
 const ClassRoom = () => {
   return (
-    <main className="flex h-full w-full flex-row">
+    <>
       classRoom
       {/* 
       section은 각 기능의 컴포넌트에서 감싸주세요!
@@ -9,7 +9,7 @@ const ClassRoom = () => {
       <section>video</section>
       <section>chat </section> 
       */}
-    </main>
+    </>
   );
 };
 export default ClassRoom;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #6 

## 📝 작업 내용
1. nav코드 분리
2. height크기 에러 수정

### 스크린샷 (선택)
기존과 동일합니다.

## 💬 리뷰 요구사항(선택)
1. main태그가 BasicLayout으로 포함되었습니다. 확인해주세요. 이부분은 추후에 변경이 많아질 경우 분리될 수 있습니다.
2. 좌측 메뉴화면이 생길수있어 layout에 포함될 컴포넌트를 components->layout에 분리하였습니다.
